### PR TITLE
fix: exclude master computer from worker assignment

### DIFF
--- a/cluster_installer.lua
+++ b/cluster_installer.lua
@@ -14,6 +14,7 @@ print("Master disk: " .. (myDrive or "NONE"))
 local workerDrives = {}
 local workerComputers = {}
 
+local myID = os.getComputerID()
 for _, name in ipairs(peripheral.getNames()) do
     local pType = peripheral.getType(name)
     if pType == "drive" and name ~= "back" then
@@ -22,7 +23,10 @@ for _, name in ipairs(peripheral.getNames()) do
             table.insert(workerDrives, {name = name, path = path})
         end
     elseif pType == "computer" then
-        table.insert(workerComputers, {name = name, id = peripheral.call(name, "getID")})
+        local cid = peripheral.call(name, "getID")
+        if cid ~= myID then
+            table.insert(workerComputers, {name = name, id = cid})
+        end
     end
 end
 
@@ -231,9 +235,13 @@ local PROTOCOL, workers, roles = "MODUS_CLUSTER", {}, {"language","knowledge","m
 for _, n in ipairs(peripheral.getNames()) do if peripheral.getType(n)=="modem" then rednet.open(n) end end
 
 print("=== MODUS v11 ===")
+local myMasterID = os.getComputerID()
 local comps = {}
 for _, n in ipairs(peripheral.getNames()) do
-    if peripheral.getType(n) == "computer" then table.insert(comps, {name=n, id=peripheral.call(n,"getID")}) end
+    if peripheral.getType(n) == "computer" then
+        local cid = peripheral.call(n,"getID")
+        if cid ~= myMasterID then table.insert(comps, {name=n, id=cid}) end
+    end
 end
 
 print("Assigning roles...")

--- a/cluster_installer_v2.lua
+++ b/cluster_installer_v2.lua
@@ -25,6 +25,7 @@ end
 local workerDrives = {}
 local workerComputers = {}
 
+local masterID = os.getComputerID()
 for _, name in ipairs(peripheral.getNames()) do
     local pType = peripheral.getType(name)
     if pType == "drive" and name ~= "back" then
@@ -33,7 +34,10 @@ for _, name in ipairs(peripheral.getNames()) do
             table.insert(workerDrives, {name = name, path = path})
         end
     elseif pType == "computer" then
-        table.insert(workerComputers, {name = name, id = peripheral.call(name, "getID")})
+        local cid = peripheral.call(name, "getID")
+        if cid ~= masterID then
+            table.insert(workerComputers, {name = name, id = cid})
+        end
     end
 end
 

--- a/superai_cluster.lua
+++ b/superai_cluster.lua
@@ -103,12 +103,14 @@ function M.init()
         end
     end
 
-    -- Discover worker computers
+    -- Discover worker computers (exclude master itself)
     local computers = {}
     for _, name in ipairs(peripheral.getNames()) do
         if peripheral.getType(name) == "computer" then
             local id = peripheral.call(name, "getID")
-            table.insert(computers, {name = name, id = id})
+            if id ~= M.masterID then
+                table.insert(computers, {name = name, id = id})
+            end
         end
     end
 


### PR DESCRIPTION
Fixes #6

All 3 installers/orchestrators were including the master computer itself when scanning for worker computers via peripheral.getNames(). This caused the master (with disk 3) to be assigned as a worker and workers to show incorrect disk numbers.

Added master ID check to filter out the master from the computer list in all three files.

Generated with [Claude Code](https://claude.ai/code)