### PR TITLE
Remove RAID system and drive_config dependencies

### DIFF
--- a/exponential_trainer.lua
+++ b/exponential_trainer.lua
@@ -524,13 +524,7 @@ function M.train(num_conversations, turns_per_conversation)
         return
     end
     
-    -- Initialize RAID for progress saving
-    local raid = nil
-    pcall(function()
-        local r = require("raid_system")
-        r.init()
-        raid = r
-    end)
+    -- Using local file system for progress saving
     
     print("Training " .. num_conversations .. " conversations...")
     print("Complexity level: " .. getComplexityLevel())


### PR DESCRIPTION
Removes all dependencies on `raid_system.lua` and `drive_config.lua` from the AI system.

### Changes
- Removed drive_config.lua requirements from main_logic.lua
- Removed DRIVES table setup and peripheral configuration
- Removed RAID system initialization and usage
- Simplified loadMemory() and saveMemory() to use only local filesystem
- Simplified getSystemHealth() to show only local computer storage
- Removed RAID initialization from exponential_trainer.lua

All AI systems now use local file system storage exclusively.

Fixes #25

Generated with [Claude Code](https://claude.ai/code)