### PR TITLE
fix: restore chat color prompts and remove backup redundancy

### DIFF
--- a/cluster_installer.lua
+++ b/cluster_installer.lua
@@ -99,12 +99,7 @@ local function findMasterBrain()
         return "master_brain.lua" 
     end
     
-    -- Try backup location in current directory
-    if fs.exists("master_brain_backup.lua") then
-        return "master_brain_backup.lua"
-    end
-    
-    -- Try disk locations
+    -- Try disk locations (backup removed to save space)
     local p = disk.getMountPath("back")
     if p and fs.exists(p.."/master_brain.lua") then 
         return p.."/master_brain.lua" 
@@ -124,11 +119,12 @@ print("=== MODUS Enhanced Auto-Startup ===")
 local masterPath = findMasterBrain()
 if masterPath then 
     print("Starting enhanced master_brain from: " .. masterPath)
+    print("Auto-startup enabled - will run on every reboot")
     shell.run(masterPath)
 else 
     print("ERROR: master_brain.lua not found!")
     print("Please run cluster_installer.lua to install the system.")
-    print("Searched locations: master_brain.lua, master_brain_backup.lua, disk locations")
+    print("Searched locations: master_brain.lua, disk locations")
 end
 ]]
 
@@ -306,11 +302,9 @@ if myDrive then
     print("  + Enhanced master_brain.lua copied to " .. myDrive)
 end
 
--- Create backup copy in current directory
-if not fs.exists("master_brain_backup.lua") then
-    fs.copy("master_brain.lua", "master_brain_backup.lua")
-    print("  + Enhanced master_brain.lua backup created")
-end
+-- Skip creating backup copy to save space
+-- User reported space is precious, removed redundancy backup
+print("  + Backup creation skipped (space optimization)")
 
 print("  + Enhanced master_brain.lua fully installed")
 

--- a/master_brain.lua
+++ b/master_brain.lua
@@ -831,9 +831,10 @@ function M.run()
             end
             
         elseif input == "settings" then
+            -- Reset settings to trigger setup without forcing white color
             settings.userName = "User"
             settings.botName = "MODUS"
-            settings.chatColor = colors.white
+            settings.chatColor = nil  -- Force re-prompt for color choice
             firstRunSetup()
             user = settings.userName
             BOT_NAME = settings.botName


### PR DESCRIPTION
Fixes three user-reported issues:

- Chat color choice no longer being prompted
- Unnecessary backup files wasting space
- Auto-startup clarity improvements

Generated with [Claude Code](https://claude.ai/code)