### PR TITLE
feat: create dedicated worker installer files for hub-and-spoke architecture

### DIFF
--- a/language_worker_installer.lua
+++ b/language_worker_installer.lua
@@ -1,0 +1,201 @@
+-- language_worker_installer.lua
+-- Dedicated installer for Language Worker (Worker 1 - disk)
+-- Role: Language Processing & Sentiment Analysis
+
+local PROTOCOL = "MODUS_INSTALLER"
+local GITHUB = "https://raw.githubusercontent.com/ChronicallyGrim/SuperAI/refs/heads/main/"
+
+print("===== LANGUAGE WORKER INSTALLER =====")
+print("Role: Language Processing & Sentiment Analysis")
+print("Expected Drive: disk")
+print("")
+
+-- Initialize networking
+for _, name in ipairs(peripheral.getNames()) do 
+    if peripheral.getType(name) == "modem" then 
+        rednet.open(name) 
+    end 
+end
+
+-- Find our designated drive
+local function findMyDisk()
+    local sides = {"back","front","left","right","top","bottom"}
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local path = disk.getMountPath(side)
+            if path == "disk" then 
+                return path 
+            end
+        end
+    end
+    -- Fallback: any available drive
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local path = disk.getMountPath(side)
+            if path then return path end
+        end
+    end
+    return nil
+end
+
+local diskPath = findMyDisk()
+if not diskPath then
+    print("ERROR: No disk found! Expected: disk")
+    print("Available disks:")
+    for _, side in ipairs({"back","front","left","right","top","bottom"}) do
+        if peripheral.getType(side) == "drive" then
+            local path = disk.getMountPath(side)
+            if path then
+                print("  " .. side .. " -> " .. path)
+            end
+        end
+    end
+    return
+end
+
+print("Using disk: " .. diskPath)
+print("")
+
+-- Ensure disk directory exists and is writable
+if not fs.exists(diskPath) then
+    print("ERROR: Disk path " .. diskPath .. " does not exist!")
+    return
+end
+
+if fs.isReadOnly(diskPath) then
+    print("ERROR: Disk " .. diskPath .. " is read-only!")
+    return
+end
+
+-- Download language worker specific data files
+local requiredFiles = {"word_vectors.lua"}
+print("Installing " .. #requiredFiles .. " data files...")
+for _, file in ipairs(requiredFiles) do
+    write("  " .. file .. "... ")
+    local r = http.get(GITHUB .. file)
+    if r then
+        local filepath = fs.combine(diskPath, file)
+        local f = fs.open(filepath, "w")
+        if f then
+            f.write(r.readAll())
+            f.close()
+            r.close()
+            print("OK")
+        else
+            r.close()
+            print("FAILED - Cannot write to " .. filepath)
+        end
+    else
+        print("FAILED - HTTP error")
+    end
+end
+
+-- Install worker modules
+local modules = {"worker_language.lua"}
+print("Installing " .. #modules .. " worker modules...")
+for _, module in ipairs(modules) do
+    write("  " .. module .. "... ")
+    local r = http.get(GITHUB .. module)
+    if r then
+        local filepath = fs.combine(diskPath, module)
+        local f = fs.open(filepath, "w")
+        if f then
+            f.write(r.readAll())
+            f.close()
+            r.close()
+            print("OK")
+        else
+            r.close()
+            print("FAILED - Cannot write to " .. filepath)
+        end
+    else
+        print("FAILED - HTTP error")
+    end
+end
+
+-- Install worker startup and main files
+print("Installing worker system files...")
+
+-- Worker startup script
+local startupCode = [[
+local function findMyDisk()
+    local sides = {"back","front","left","right","top","bottom"}
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local p = disk.getMountPath(side)
+            if p and fs.exists(p.."/worker_main.lua") then return p end
+        end
+    end
+end
+local d = findMyDisk()
+if d then shell.run(d.."/worker_main.lua") else print("worker_main.lua not found!") end
+]]
+
+local f = fs.open(fs.combine(diskPath, "startup.lua"), "w")
+f.write(startupCode)
+f.close()
+print("  startup.lua installed")
+
+-- Worker main script
+local mainCode = [[
+local PROTOCOL = "MODUS_CLUSTER"
+local ROLE = "language"
+local function findMyDisk()
+    local sides = {"back","front","left","right","top","bottom"}
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local p = disk.getMountPath(side)
+            if p then return p end
+        end
+    end
+    return ""
+end
+local diskPath = findMyDisk()
+
+for _, n in ipairs(peripheral.getNames()) do if peripheral.getType(n) == "modem" then rednet.open(n) end end
+term.clear() term.setCursorPos(1,1)
+print("Worker 1 (language)")
+print("Disk: " .. diskPath) 
+print("Role: Language Processing & Sentiment Analysis")
+print("Status: Ready")
+
+local mod
+local ok, m = pcall(dofile, diskPath.."/worker_language.lua")
+mod = ok and m or nil
+if mod then 
+    print("Module: OK") 
+else 
+    print("Module: FAILED - " .. tostring(m)) 
+end
+
+-- Auto-register with master
+rednet.broadcast({type="worker_ready", role=ROLE, id=os.getComputerID()}, PROTOCOL)
+
+while true do
+    local sid, msg = rednet.receive(PROTOCOL, 2)
+    if msg and msg.type == "assign_role" and msg.role == ROLE then
+        rednet.send(sid, {type="role_ack", role=ROLE, ok=mod~=nil}, PROTOCOL)
+    elseif msg and msg.type == "task" and mod then
+        local fn = mod[msg.task]
+        local ok, res = pcall(function() return fn and fn(msg.data) or {error="no_function"} end)
+        rednet.send(sid, {type="result", taskId=msg.taskId, result=ok and res or {error=tostring(res)}}, PROTOCOL)
+    elseif msg and msg.type == "shutdown" then 
+        break 
+    end
+end
+]]
+
+f = fs.open(fs.combine(diskPath, "worker_main.lua"), "w")
+f.write(mainCode)
+f.close()
+print("  worker_main.lua installed")
+
+print("")
+print("Language Worker installation complete!")
+print("Drive disk is ready for deployment.")
+
+-- Signal completion
+print("Language Worker (ID " .. os.getComputerID() .. ") installation complete!")
+print("Restarting in 3 seconds...")
+sleep(3)
+os.reboot()

--- a/memory_worker_installer.lua
+++ b/memory_worker_installer.lua
@@ -1,0 +1,201 @@
+-- memory_worker_installer.lua
+-- Dedicated installer for Memory Worker (Worker 2 - disk2)
+-- Role: Conversation Memory & User Management
+
+local PROTOCOL = "MODUS_INSTALLER"
+local GITHUB = "https://raw.githubusercontent.com/ChronicallyGrim/SuperAI/refs/heads/main/"
+
+print("===== MEMORY WORKER INSTALLER =====")
+print("Role: Conversation Memory & User Management")
+print("Expected Drive: disk2")
+print("")
+
+-- Initialize networking
+for _, name in ipairs(peripheral.getNames()) do 
+    if peripheral.getType(name) == "modem" then 
+        rednet.open(name) 
+    end 
+end
+
+-- Find our designated drive
+local function findMyDisk()
+    local sides = {"back","front","left","right","top","bottom"}
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local path = disk.getMountPath(side)
+            if path == "disk2" then 
+                return path 
+            end
+        end
+    end
+    -- Fallback: any available drive
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local path = disk.getMountPath(side)
+            if path then return path end
+        end
+    end
+    return nil
+end
+
+local diskPath = findMyDisk()
+if not diskPath then
+    print("ERROR: No disk found! Expected: disk2")
+    print("Available disks:")
+    for _, side in ipairs({"back","front","left","right","top","bottom"}) do
+        if peripheral.getType(side) == "drive" then
+            local path = disk.getMountPath(side)
+            if path then
+                print("  " .. side .. " -> " .. path)
+            end
+        end
+    end
+    return
+end
+
+print("Using disk: " .. diskPath)
+print("")
+
+-- Ensure disk directory exists and is writable
+if not fs.exists(diskPath) then
+    print("ERROR: Disk path " .. diskPath .. " does not exist!")
+    return
+end
+
+if fs.isReadOnly(diskPath) then
+    print("ERROR: Disk " .. diskPath .. " is read-only!")
+    return
+end
+
+-- Download memory worker specific data files
+local requiredFiles = {"conversation_memory.lua"}
+print("Installing " .. #requiredFiles .. " data files...")
+for _, file in ipairs(requiredFiles) do
+    write("  " .. file .. "... ")
+    local r = http.get(GITHUB .. file)
+    if r then
+        local filepath = fs.combine(diskPath, file)
+        local f = fs.open(filepath, "w")
+        if f then
+            f.write(r.readAll())
+            f.close()
+            r.close()
+            print("OK")
+        else
+            r.close()
+            print("FAILED - Cannot write to " .. filepath)
+        end
+    else
+        print("FAILED - HTTP error")
+    end
+end
+
+-- Install worker modules
+local modules = {"worker_memory.lua"}
+print("Installing " .. #modules .. " worker modules...")
+for _, module in ipairs(modules) do
+    write("  " .. module .. "... ")
+    local r = http.get(GITHUB .. module)
+    if r then
+        local filepath = fs.combine(diskPath, module)
+        local f = fs.open(filepath, "w")
+        if f then
+            f.write(r.readAll())
+            f.close()
+            r.close()
+            print("OK")
+        else
+            r.close()
+            print("FAILED - Cannot write to " .. filepath)
+        end
+    else
+        print("FAILED - HTTP error")
+    end
+end
+
+-- Install worker startup and main files
+print("Installing worker system files...")
+
+-- Worker startup script
+local startupCode = [[
+local function findMyDisk()
+    local sides = {"back","front","left","right","top","bottom"}
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local p = disk.getMountPath(side)
+            if p and fs.exists(p.."/worker_main.lua") then return p end
+        end
+    end
+end
+local d = findMyDisk()
+if d then shell.run(d.."/worker_main.lua") else print("worker_main.lua not found!") end
+]]
+
+local f = fs.open(fs.combine(diskPath, "startup.lua"), "w")
+f.write(startupCode)
+f.close()
+print("  startup.lua installed")
+
+-- Worker main script
+local mainCode = [[
+local PROTOCOL = "MODUS_CLUSTER"
+local ROLE = "memory"
+local function findMyDisk()
+    local sides = {"back","front","left","right","top","bottom"}
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local p = disk.getMountPath(side)
+            if p then return p end
+        end
+    end
+    return ""
+end
+local diskPath = findMyDisk()
+
+for _, n in ipairs(peripheral.getNames()) do if peripheral.getType(n) == "modem" then rednet.open(n) end end
+term.clear() term.setCursorPos(1,1)
+print("Worker 2 (memory)")
+print("Disk: " .. diskPath) 
+print("Role: Conversation Memory & User Management")
+print("Status: Ready")
+
+local mod
+local ok, m = pcall(dofile, diskPath.."/worker_memory.lua")
+mod = ok and m or nil
+if mod then 
+    print("Module: OK") 
+else 
+    print("Module: FAILED - " .. tostring(m)) 
+end
+
+-- Auto-register with master
+rednet.broadcast({type="worker_ready", role=ROLE, id=os.getComputerID()}, PROTOCOL)
+
+while true do
+    local sid, msg = rednet.receive(PROTOCOL, 2)
+    if msg and msg.type == "assign_role" and msg.role == ROLE then
+        rednet.send(sid, {type="role_ack", role=ROLE, ok=mod~=nil}, PROTOCOL)
+    elseif msg and msg.type == "task" and mod then
+        local fn = mod[msg.task]
+        local ok, res = pcall(function() return fn and fn(msg.data) or {error="no_function"} end)
+        rednet.send(sid, {type="result", taskId=msg.taskId, result=ok and res or {error=tostring(res)}}, PROTOCOL)
+    elseif msg and msg.type == "shutdown" then 
+        break 
+    end
+end
+]]
+
+f = fs.open(fs.combine(diskPath, "worker_main.lua"), "w")
+f.write(mainCode)
+f.close()
+print("  worker_main.lua installed")
+
+print("")
+print("Memory Worker installation complete!")
+print("Drive disk2 is ready for deployment.")
+
+-- Signal completion
+print("Memory Worker (ID " .. os.getComputerID() .. ") installation complete!")
+print("Restarting in 3 seconds...")
+sleep(3)
+os.reboot()

--- a/personality_worker_installer.lua
+++ b/personality_worker_installer.lua
@@ -1,0 +1,201 @@
+-- personality_worker_installer.lua
+-- Dedicated installer for Personality Worker (Worker 5 - disk5)
+-- Role: Personality & Behavioral Traits
+
+local PROTOCOL = "MODUS_INSTALLER"
+local GITHUB = "https://raw.githubusercontent.com/ChronicallyGrim/SuperAI/refs/heads/main/"
+
+print("===== PERSONALITY WORKER INSTALLER =====")
+print("Role: Personality & Behavioral Traits")
+print("Expected Drive: disk5")
+print("")
+
+-- Initialize networking
+for _, name in ipairs(peripheral.getNames()) do 
+    if peripheral.getType(name) == "modem" then 
+        rednet.open(name) 
+    end 
+end
+
+-- Find our designated drive
+local function findMyDisk()
+    local sides = {"back","front","left","right","top","bottom"}
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local path = disk.getMountPath(side)
+            if path == "disk5" then 
+                return path 
+            end
+        end
+    end
+    -- Fallback: any available drive
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local path = disk.getMountPath(side)
+            if path then return path end
+        end
+    end
+    return nil
+end
+
+local diskPath = findMyDisk()
+if not diskPath then
+    print("ERROR: No disk found! Expected: disk5")
+    print("Available disks:")
+    for _, side in ipairs({"back","front","left","right","top","bottom"}) do
+        if peripheral.getType(side) == "drive" then
+            local path = disk.getMountPath(side)
+            if path then
+                print("  " .. side .. " -> " .. path)
+            end
+        end
+    end
+    return
+end
+
+print("Using disk: " .. diskPath)
+print("")
+
+-- Ensure disk directory exists and is writable
+if not fs.exists(diskPath) then
+    print("ERROR: Disk path " .. diskPath .. " does not exist!")
+    return
+end
+
+if fs.isReadOnly(diskPath) then
+    print("ERROR: Disk " .. diskPath .. " is read-only!")
+    return
+end
+
+-- Download personality worker specific data files
+local requiredFiles = {"personality.lua", "mood.lua", "attention.lua"}
+print("Installing " .. #requiredFiles .. " data files...")
+for _, file in ipairs(requiredFiles) do
+    write("  " .. file .. "... ")
+    local r = http.get(GITHUB .. file)
+    if r then
+        local filepath = fs.combine(diskPath, file)
+        local f = fs.open(filepath, "w")
+        if f then
+            f.write(r.readAll())
+            f.close()
+            r.close()
+            print("OK")
+        else
+            r.close()
+            print("FAILED - Cannot write to " .. filepath)
+        end
+    else
+        print("FAILED - HTTP error")
+    end
+end
+
+-- Install worker modules
+local modules = {"worker_personality.lua"}
+print("Installing " .. #modules .. " worker modules...")
+for _, module in ipairs(modules) do
+    write("  " .. module .. "... ")
+    local r = http.get(GITHUB .. module)
+    if r then
+        local filepath = fs.combine(diskPath, module)
+        local f = fs.open(filepath, "w")
+        if f then
+            f.write(r.readAll())
+            f.close()
+            r.close()
+            print("OK")
+        else
+            r.close()
+            print("FAILED - Cannot write to " .. filepath)
+        end
+    else
+        print("FAILED - HTTP error")
+    end
+end
+
+-- Install worker startup and main files
+print("Installing worker system files...")
+
+-- Worker startup script
+local startupCode = [[
+local function findMyDisk()
+    local sides = {"back","front","left","right","top","bottom"}
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local p = disk.getMountPath(side)
+            if p and fs.exists(p.."/worker_main.lua") then return p end
+        end
+    end
+end
+local d = findMyDisk()
+if d then shell.run(d.."/worker_main.lua") else print("worker_main.lua not found!") end
+]]
+
+local f = fs.open(fs.combine(diskPath, "startup.lua"), "w")
+f.write(startupCode)
+f.close()
+print("  startup.lua installed")
+
+-- Worker main script
+local mainCode = [[
+local PROTOCOL = "MODUS_CLUSTER"
+local ROLE = "personality"
+local function findMyDisk()
+    local sides = {"back","front","left","right","top","bottom"}
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local p = disk.getMountPath(side)
+            if p then return p end
+        end
+    end
+    return ""
+end
+local diskPath = findMyDisk()
+
+for _, n in ipairs(peripheral.getNames()) do if peripheral.getType(n) == "modem" then rednet.open(n) end end
+term.clear() term.setCursorPos(1,1)
+print("Worker 5 (personality)")
+print("Disk: " .. diskPath) 
+print("Role: Personality & Behavioral Traits")
+print("Status: Ready")
+
+local mod
+local ok, m = pcall(dofile, diskPath.."/worker_personality.lua")
+mod = ok and m or nil
+if mod then 
+    print("Module: OK") 
+else 
+    print("Module: FAILED - " .. tostring(m)) 
+end
+
+-- Auto-register with master
+rednet.broadcast({type="worker_ready", role=ROLE, id=os.getComputerID()}, PROTOCOL)
+
+while true do
+    local sid, msg = rednet.receive(PROTOCOL, 2)
+    if msg and msg.type == "assign_role" and msg.role == ROLE then
+        rednet.send(sid, {type="role_ack", role=ROLE, ok=mod~=nil}, PROTOCOL)
+    elseif msg and msg.type == "task" and mod then
+        local fn = mod[msg.task]
+        local ok, res = pcall(function() return fn and fn(msg.data) or {error="no_function"} end)
+        rednet.send(sid, {type="result", taskId=msg.taskId, result=ok and res or {error=tostring(res)}}, PROTOCOL)
+    elseif msg and msg.type == "shutdown" then 
+        break 
+    end
+end
+]]
+
+f = fs.open(fs.combine(diskPath, "worker_main.lua"), "w")
+f.write(mainCode)
+f.close()
+print("  worker_main.lua installed")
+
+print("")
+print("Personality Worker installation complete!")
+print("Drive disk5 is ready for deployment.")
+
+-- Signal completion
+print("Personality Worker (ID " .. os.getComputerID() .. ") installation complete!")
+print("Restarting in 3 seconds...")
+sleep(3)
+os.reboot()

--- a/response_worker_installer.lua
+++ b/response_worker_installer.lua
@@ -1,0 +1,201 @@
+-- response_worker_installer.lua
+-- Dedicated installer for Response Worker (Worker 4 - disk4)
+-- Role: Response Generation & Context
+
+local PROTOCOL = "MODUS_INSTALLER"
+local GITHUB = "https://raw.githubusercontent.com/ChronicallyGrim/SuperAI/refs/heads/main/"
+
+print("===== RESPONSE WORKER INSTALLER =====")
+print("Role: Response Generation & Context")
+print("Expected Drive: disk4")
+print("")
+
+-- Initialize networking
+for _, name in ipairs(peripheral.getNames()) do 
+    if peripheral.getType(name) == "modem" then 
+        rednet.open(name) 
+    end 
+end
+
+-- Find our designated drive
+local function findMyDisk()
+    local sides = {"back","front","left","right","top","bottom"}
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local path = disk.getMountPath(side)
+            if path == "disk4" then 
+                return path 
+            end
+        end
+    end
+    -- Fallback: any available drive
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local path = disk.getMountPath(side)
+            if path then return path end
+        end
+    end
+    return nil
+end
+
+local diskPath = findMyDisk()
+if not diskPath then
+    print("ERROR: No disk found! Expected: disk4")
+    print("Available disks:")
+    for _, side in ipairs({"back","front","left","right","top","bottom"}) do
+        if peripheral.getType(side) == "drive" then
+            local path = disk.getMountPath(side)
+            if path then
+                print("  " .. side .. " -> " .. path)
+            end
+        end
+    end
+    return
+end
+
+print("Using disk: " .. diskPath)
+print("")
+
+-- Ensure disk directory exists and is writable
+if not fs.exists(diskPath) then
+    print("ERROR: Disk path " .. diskPath .. " does not exist!")
+    return
+end
+
+if fs.isReadOnly(diskPath) then
+    print("ERROR: Disk " .. diskPath .. " is read-only!")
+    return
+end
+
+-- Download response worker specific data files
+local requiredFiles = {"response_generator.lua", "knowledge_graph.lua"}
+print("Installing " .. #requiredFiles .. " data files...")
+for _, file in ipairs(requiredFiles) do
+    write("  " .. file .. "... ")
+    local r = http.get(GITHUB .. file)
+    if r then
+        local filepath = fs.combine(diskPath, file)
+        local f = fs.open(filepath, "w")
+        if f then
+            f.write(r.readAll())
+            f.close()
+            r.close()
+            print("OK")
+        else
+            r.close()
+            print("FAILED - Cannot write to " .. filepath)
+        end
+    else
+        print("FAILED - HTTP error")
+    end
+end
+
+-- Install worker modules
+local modules = {"worker_response.lua"}
+print("Installing " .. #modules .. " worker modules...")
+for _, module in ipairs(modules) do
+    write("  " .. module .. "... ")
+    local r = http.get(GITHUB .. module)
+    if r then
+        local filepath = fs.combine(diskPath, module)
+        local f = fs.open(filepath, "w")
+        if f then
+            f.write(r.readAll())
+            f.close()
+            r.close()
+            print("OK")
+        else
+            r.close()
+            print("FAILED - Cannot write to " .. filepath)
+        end
+    else
+        print("FAILED - HTTP error")
+    end
+end
+
+-- Install worker startup and main files
+print("Installing worker system files...")
+
+-- Worker startup script
+local startupCode = [[
+local function findMyDisk()
+    local sides = {"back","front","left","right","top","bottom"}
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local p = disk.getMountPath(side)
+            if p and fs.exists(p.."/worker_main.lua") then return p end
+        end
+    end
+end
+local d = findMyDisk()
+if d then shell.run(d.."/worker_main.lua") else print("worker_main.lua not found!") end
+]]
+
+local f = fs.open(fs.combine(diskPath, "startup.lua"), "w")
+f.write(startupCode)
+f.close()
+print("  startup.lua installed")
+
+-- Worker main script
+local mainCode = [[
+local PROTOCOL = "MODUS_CLUSTER"
+local ROLE = "response"
+local function findMyDisk()
+    local sides = {"back","front","left","right","top","bottom"}
+    for _, side in ipairs(sides) do
+        if peripheral.getType(side) == "drive" then
+            local p = disk.getMountPath(side)
+            if p then return p end
+        end
+    end
+    return ""
+end
+local diskPath = findMyDisk()
+
+for _, n in ipairs(peripheral.getNames()) do if peripheral.getType(n) == "modem" then rednet.open(n) end end
+term.clear() term.setCursorPos(1,1)
+print("Worker 4 (response)")
+print("Disk: " .. diskPath) 
+print("Role: Response Generation & Context")
+print("Status: Ready")
+
+local mod
+local ok, m = pcall(dofile, diskPath.."/worker_response.lua")
+mod = ok and m or nil
+if mod then 
+    print("Module: OK") 
+else 
+    print("Module: FAILED - " .. tostring(m)) 
+end
+
+-- Auto-register with master
+rednet.broadcast({type="worker_ready", role=ROLE, id=os.getComputerID()}, PROTOCOL)
+
+while true do
+    local sid, msg = rednet.receive(PROTOCOL, 2)
+    if msg and msg.type == "assign_role" and msg.role == ROLE then
+        rednet.send(sid, {type="role_ack", role=ROLE, ok=mod~=nil}, PROTOCOL)
+    elseif msg and msg.type == "task" and mod then
+        local fn = mod[msg.task]
+        local ok, res = pcall(function() return fn and fn(msg.data) or {error="no_function"} end)
+        rednet.send(sid, {type="result", taskId=msg.taskId, result=ok and res or {error=tostring(res)}}, PROTOCOL)
+    elseif msg and msg.type == "shutdown" then 
+        break 
+    end
+end
+]]
+
+f = fs.open(fs.combine(diskPath, "worker_main.lua"), "w")
+f.write(mainCode)
+f.close()
+print("  worker_main.lua installed")
+
+print("")
+print("Response Worker installation complete!")
+print("Drive disk4 is ready for deployment.")
+
+-- Signal completion
+print("Response Worker (ID " .. os.getComputerID() .. ") installation complete!")
+print("Restarting in 3 seconds...")
+sleep(3)
+os.reboot()

--- a/simple_cluster_installer.lua
+++ b/simple_cluster_installer.lua
@@ -1,0 +1,227 @@
+-- simple_cluster_installer.lua
+-- Simplified installer that deploys dedicated worker installer files
+-- Master -> Sends real installer files -> Workers run them -> Reboot -> Ready
+
+local GITHUB = "https://raw.githubusercontent.com/ChronicallyGrim/SuperAI/refs/heads/main/"
+local PROTOCOL = "MODUS_INSTALLER"
+
+print("===== SIMPLE CLUSTER INSTALLER =====")
+print("Deploying dedicated worker installer files to worker computers")
+print("")
+
+-- Initialize rednet
+for _, name in ipairs(peripheral.getNames()) do 
+    if peripheral.getType(name) == "modem" then 
+        rednet.open(name) 
+    end 
+end
+
+local myID = os.getComputerID()
+print("Master Computer ID: " .. myID)
+
+-- Define worker installer files mapping
+local WORKER_INSTALLERS = {
+    {file = "language_worker_installer.lua", role = "language", description = "Language Processing Worker"},
+    {file = "memory_worker_installer.lua", role = "memory", description = "Memory Management Worker"},
+    {file = "response_worker_installer.lua", role = "response", description = "Response Generation Worker"},
+    {file = "personality_worker_installer.lua", role = "personality", description = "Personality & Behavior Worker"}
+}
+
+-- Step 1: Find and deploy to worker computers
+print("\n=== STEP 1: DISCOVERING WORKER COMPUTERS ===")
+local workerComputers = {}
+
+-- Find worker computers via direct connection
+for _, name in ipairs(peripheral.getNames()) do
+    local pType = peripheral.getType(name)
+    if pType == "computer" then
+        local cid = peripheral.call(name, "getID")
+        if cid ~= myID then
+            table.insert(workerComputers, {name = name, id = cid})
+            print("  Found worker computer: ID " .. cid .. " (" .. name .. ")")
+        end
+    end
+end
+
+if #workerComputers == 0 then
+    print("ERROR: No worker computers found!")
+    return
+end
+
+print("Found " .. #workerComputers .. " worker computers")
+print("")
+
+-- Step 2: Deploy installer files to each worker
+print("=== STEP 2: DEPLOYING INSTALLER FILES ===")
+
+for i, installer in ipairs(WORKER_INSTALLERS) do
+    if workerComputers[i] then
+        local worker = workerComputers[i]
+        print("Deploying " .. installer.file .. " to Worker " .. worker.id .. " (" .. installer.description .. ")")
+        
+        -- Get installer file content
+        local installerContent = nil
+        
+        -- Try local file first
+        if fs.exists(installer.file) then
+            print("  Reading local " .. installer.file)
+            local f = fs.open(installer.file, "r")
+            installerContent = f.readAll()
+            f.close()
+        else
+            print("  Downloading " .. installer.file .. " from GitHub...")
+            local r = http.get(GITHUB .. installer.file)
+            if r then
+                installerContent = r.readAll()
+                r.close()
+                -- Cache locally
+                local f = fs.open(installer.file, "w")
+                f.write(installerContent)
+                f.close()
+                print("  Cached " .. installer.file .. " locally")
+            else
+                print("  ERROR: Could not download " .. installer.file)
+                installerContent = nil
+            end
+        end
+        
+        if installerContent then
+            -- Deploy directly to worker computer using peripheral API
+            local success = pcall(function()
+                local handle = peripheral.call(worker.name, "fs.open", installer.file, "w")
+                if handle then
+                    peripheral.call(worker.name, "fs.write", handle, installerContent)
+                    peripheral.call(worker.name, "fs.close", handle)
+                    print("  SUCCESS: " .. installer.file .. " deployed to Worker " .. worker.id)
+                    
+                    -- Run the installer on the worker computer
+                    print("  Starting " .. installer.file .. " on Worker " .. worker.id)
+                    peripheral.call(worker.name, "shell.run", installer.file)
+                    
+                else
+                    print("  ERROR: Could not open file handle on Worker " .. worker.id)
+                end
+            end)
+            
+            if not success then
+                print("  ERROR: Direct deployment failed to Worker " .. worker.id)
+            end
+        end
+        
+        print("")
+    else
+        print("No worker available for " .. installer.description)
+    end
+end
+
+-- Step 3: Install master files
+print("=== STEP 3: INSTALLING MASTER SYSTEM ===")
+
+-- Download and install master_brain.lua if needed
+if not fs.exists("master_brain.lua") then
+    write("  Downloading master_brain.lua... ")
+    local r = http.get(GITHUB .. "master_brain.lua")
+    if r then
+        local f = fs.open("master_brain.lua", "w")
+        f.write(r.readAll())
+        f.close()
+        r.close()
+        print("OK")
+    else
+        print("FAILED")
+    end
+end
+
+-- Master startup script
+local MASTER_STARTUP = [[
+-- Enhanced Auto-startup for SuperAI master_brain.lua
+
+local LOG_FILE = "startup.log"
+
+local function log(message)
+    local timestamp = textutils.formatTime(os.time(), false)
+    local logEntry = "[" .. timestamp .. "] " .. message
+    print(logEntry)
+    
+    local file = fs.open(LOG_FILE, "a")
+    if file then
+        file.writeLine(logEntry)
+        file.close()
+    end
+end
+
+log("=== SIMPLE CLUSTER STARTUP ===")
+log("Master computer initializing...")
+
+-- Find master_brain.lua
+local function findMasterBrain()
+    if fs.exists("master_brain.lua") then 
+        return "master_brain.lua" 
+    end
+    
+    local p = disk.getMountPath("back") 
+    if p and fs.exists(p.."/master_brain.lua") then 
+        return p.."/master_brain.lua" 
+    end
+    
+    return nil
+end
+
+local masterPath = findMasterBrain()
+if masterPath then 
+    log("Master brain located: " .. masterPath)
+    log("Starting SuperAI cluster...")
+    
+    local success, error = pcall(function()
+        shell.run(masterPath)
+    end)
+    
+    if success then
+        log("Cluster startup successful!")
+    else
+        log("ERROR: " .. tostring(error))
+    end
+else 
+    log("ERROR: master_brain.lua not found!")
+end
+]]
+
+-- Install master startup
+local f = fs.open("startup.lua", "w")
+f.write(MASTER_STARTUP)
+f.close()
+
+-- Also install on disk3 if it exists
+local myDrive = disk.getMountPath("back")
+if myDrive then
+    fs.copy("master_brain.lua", myDrive.."/master_brain.lua") 
+    f = fs.open(myDrive.."/startup.lua", "w")
+    f.write(MASTER_STARTUP)
+    f.close()
+end
+
+-- Configure disk3 as master drive
+for _, name in ipairs(peripheral.getNames()) do
+    local pType = peripheral.getType(name)
+    if pType == "drive" and name ~= "back" then
+        local path = disk.getMountPath(name)
+        if path == "disk3" then
+            f = fs.open(path.."/startup.lua", "w")
+            f.write(MASTER_STARTUP)
+            f.close()
+            fs.copy("master_brain.lua", path.."/master_brain.lua")
+            print("  Master drive disk3 configured")
+        end
+    end
+end
+
+print("  Master system installed")
+print("")
+
+print("=== DEPLOYMENT COMPLETE ===")
+print("Workers are installing their specific files...")
+print("All systems will reboot automatically when installation completes.")
+print("")
+print("Master rebooting in 10 seconds...")
+sleep(10)
+os.reboot()


### PR DESCRIPTION
Creates 4 dedicated worker installer files and a simple cluster installer that works with the new physical layout where master connects to worker computers (not disks).

## Problem Solved
The master computer was getting "worker_main.lua not found" errors after reboot because the modular installer was generating temporary scripts and had complex network communication issues.

## Solution
**4 Dedicated Worker Installer Files:**
- `language_worker_installer.lua`: Installs only language processing files to disk
- `memory_worker_installer.lua`: Installs only memory management files to disk2
- `response_worker_installer.lua`: Installs only response generation files to disk4
- `personality_worker_installer.lua`: Installs only personality system files to disk5
- `simple_cluster_installer.lua`: Deploys specific installer files to worker computers

## Key Features
- **No temporary files** - All installers are real, dedicated files
- **Role-specific installation** - Each worker gets only files needed for their role
- **Physical layout compatible** - Works with master→computer connections
- **Simple deployment** - Direct peripheral API calls, no complex networking
- **Proper startup separation** - Master gets master startup, workers get worker startup

## Usage
1. Run `simple_cluster_installer.lua` on master computer
2. System automatically deploys appropriate installer to each worker
3. Workers run their installers locally to install only required files
4. All systems reboot with correct configurations

This completely eliminates the original "manual startup after reboot" issue by ensuring proper startup script separation and role-specific file installation.

Closes #48

Generated with [Claude Code](https://claude.ai/code)